### PR TITLE
Time parsing on main event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ copy_src: target_dir
 	cp fluentdhec/*.py .target
 
 add_deps: target_dir
-	pip3 install -r requirements.txt --system -t .target
+	pip3 install -r requirements.txt -t .target
 
 clean:
 	rm -rf .target *.egg-info .tox venv *.zip .pytest_cache htmlcov **/__pycache__

--- a/fluentdhec/lambda_function.py
+++ b/fluentdhec/lambda_function.py
@@ -36,23 +36,18 @@ def lambda_handler(event, context):
 
 
 def extract_time(message):
-    res = False
-    regex = r'[A-Z]+\s\[(?P<timestamp>[^]]+)|usecs:(?P<usec>[0-9]+)'
+    regex = r'[A-Z]+\s\[(?P<timestamp>[^],]+)|usecs:(?P<usec>[0-9]+)'
     match = re.search(regex, message)
-    if match:
-        for poss_matches in ["timestamp", "usec"]:
-            if match.groupdict()[poss_matches] is not None:
-                res = match.groupdict()[poss_matches]
-                break
 
-        if not res.isdigit():
-            try:
-                dtmp = dateparser.parse(res)
-                res = int(dtmp.timestamp())
-            except Exception as e:
-                print(f'fluentdhec.lambda_handler:extract_time: error: {e}')
-        else:
-            res = int(res)
+    try:
+        res = [
+            int(dateparser.parse(timestamp).timestamp())
+            for timestamp in match.groupdict().values()
+            if timestamp
+        ][0]
+    except AttributeError:
+        res = False
+
     return res
 
 

--- a/fluentdhec/lambda_function.py
+++ b/fluentdhec/lambda_function.py
@@ -46,7 +46,7 @@ def extract_time(message):
     # rTime matches timestamps with optional seconds and optional timezones
     rTime = rf"\d\d\:\d\d(?:\:\d\d)?(?:[\.,]\d+)?(?:Z| AM| PM|{rTimeZone})?"
 
-    regex = rf'(?P<t>{rDOrY}.{rMonth}.{rDOrY}?.{rTime})|usecs:(?P<s>[0-9]+)'
+    regex = rf'(?P<t>{rDOrY}.{rMonth}.{rDOrY}.{rTime})|usecs:(?P<s>[0-9]+)'
     match = re.search(regex, message)
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+dateparser

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -59,6 +59,12 @@ def test_syslog_2_extract_time():
     assert resp == 1558364490
 
 
+def test_syslog_3_extract_time():
+        message = "syslog INFO 1997-07-16T19:20+01:00 temp"
+        resp = fluentdhec.lambda_function.extract_time(message)
+        assert resp == 869077200
+
+
 def test_usec_1_extract_time():
     message = "blah usecs:1558360830.123 test usec:12345 end"
     resp = fluentdhec.lambda_function.extract_time(message)

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -35,6 +35,36 @@ def context():
     return o
 
 
+def test_invalid_extract_time():
+    message = "syslog nope temp"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert not resp
+
+
+def test_syslog_1_extract_time():
+    message = "syslog INFO [20/05/2019 16:01:30.123] temp"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 1558364490
+
+
+def test_syslog_2_extract_time():
+    message = "syslog INFO [2019 May 20 04:01:30 PM] temp"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 1558364490
+
+
+def test_usec_1_extract_time():
+    message = "blah usecs:1558360830.123 test usec:12345 end"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 1558360830
+
+
+def test_usec_2_extract_time():
+    message = "blah usecs:1558360830 end"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 1558360830
+
+
 def test_lf_send_payload_k8s(k8s_event, context, mocker):
     mocker.patch.dict(os.environ, {"SPLUNK_INDEX": "k8s"})
     mocker.patch('fluentdhec.lambda_function.send_to_hec')

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -60,9 +60,16 @@ def test_syslog_2_extract_time():
 
 
 def test_syslog_3_extract_time():
-        message = "syslog INFO 1997-07-16T19:20+01:00 temp"
-        resp = fluentdhec.lambda_function.extract_time(message)
-        assert resp == 869077200
+    message = "syslog INFO 1997-07-16T19:20+01:00 temp"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 869077200
+
+
+def test_syslog_4_extract_time():
+    # should only match the first time
+    message = "syslog 2019 May 20 04:01:30 PM test 1997-07-16T19:20+01:00"
+    resp = fluentdhec.lambda_function.extract_time(message)
+    assert resp == 1558364490
 
 
 def test_usec_1_extract_time():


### PR DESCRIPTION
Currently Splunk is indexing based on event indexed time and not the time in the event.
This change extracts the timestamp and puts it in the main JSON object (along with `host` etc.)
Uses `usec` in the HSM event and syslog timestamp from k8s (timestamp in `[]`), parses the datetime object and uses `.timestamp()`