### PR TITLE
add kubernetes namespace name as a new field

### DIFF
--- a/fluentdhec/lambda_function.py
+++ b/fluentdhec/lambda_function.py
@@ -92,7 +92,7 @@ def build_payload_k8s(data, context):
 
         if "kubernetes" in jlog:
             event = {
-                "host": jlog['kubernetes']['pod_name'],
+                "host": "%s/%s" % (jlog['kubernetes']['namespace_name'], jlog['kubernetes']['pod_name']),
                 "source": cluster_name,
                 "sourcetype": jlog['kubernetes']['container_name'],
                 "index": os.environ['SPLUNK_INDEX'],


### PR DESCRIPTION
The namespace name is really useful for distinguishing different
environments - eg distinguishing prod and non-prod data.