### PR TITLE
    skip adding a time if extract_time fails

### DIFF
--- a/fluentdhec/lambda_function.py
+++ b/fluentdhec/lambda_function.py
@@ -34,7 +34,9 @@ def lambda_handler(event, context):
         event["source"] = context.function_name
         event["host"] = data.get('logGroup', 'unknown')
         if "time" not in event:
-            event["time"] = extract_time(log_event['message'])
+            t = extract_time(log_event['message'])
+            if type(t) is int:
+                event["time"] = t
         event_payload = json.dumps(event)
         send_to_hec(event_payload)
 
@@ -70,7 +72,7 @@ def parse_k8s_log_event(log):
         else:
             return parse_raw_event(log)
     except json.decoder.JSONDecodeError as e:
-        print(e, log)
+        print('failed to parse_container_log_event:', e, log)
         return parse_raw_event(log)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
    
    splunk doesn't like it when "time" field is not an int, so ensure that
    if extract_time returns junk that it is ignored. The time field is
    optional so this is a best effort type affair